### PR TITLE
chore: force target sdk 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,13 @@ buildscript {
 apply plugin: 'com.mparticle.kit'
 
 android {
+    compileSdk 30
     lintOptions {
         abortOnError false
     }
     defaultConfig {
         minSdkVersion 16
+        targetSdk 30
     }
 }
 


### PR DESCRIPTION

# Summary

force targetSdk 30. Since the underlying Reveal SDK has not upgraded to targetSdk 31, we need to override our plugin's default targetSdk to 30

