### PR TITLE
fix: Remove Reveal AAR from POM to resolve Central Publishing Portal rejection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,12 +54,13 @@ repositories {
 dependencies {
     // Changed from 'api' to 'compileOnly' to avoid invalid POM issues
     compileOnly files('libs/reveal-1.4.22-android12.aar')
+    testImplementation files('libs/reveal-1.4.22-android12.aar')
 
     // If ever published as a proper Maven artifact, you can switch to:
     // api 'com.revealmobile:reveal:1.4.22'
 }
 
-// ✨ Remove invalid dependency blocks from the published POM
+// Remove invalid dependency blocks from the published POM
 afterEvaluate {
     publishing {
         publications {

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,26 @@ repositories {
 }
 
 dependencies {
-    api(name:'reveal-1.4.22-android12', ext:'aar')
-    //api 'com.stepleaderdigital.reveal:reveal:1.4.22'
+    // Changed from 'api' to 'compileOnly' to avoid invalid POM issues
+    compileOnly files('libs/reveal-1.4.22-android12.aar')
+
+    // If ever published as a proper Maven artifact, you can switch to:
+    // api 'com.revealmobile:reveal:1.4.22'
+}
+
+// ✨ Remove invalid dependency blocks from the published POM
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                pom.withXml {
+                    def dependenciesNode = asNode().get('dependencies')
+                    dependenciesNode?.removeAll {
+                        def groupId = it.getAt('groupId')[0]?.text()
+                        return groupId == null || groupId.trim() == ''
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR addresses a Maven Central validation failure when publishing the android-revealmobile-kit via the new Central Publishing Portal (CPP). Previously, we included a local AAR file using a flatDir dependency. While this worked with the older OSSRH (Nexus) system, the new CPP enforces stricter validation rules.
Specifically, CPP fails publishing if any dependency in the generated .pom is missing required metadata such as groupId, artifactId, or version. Local .aar files do not contain this metadata, which causes the publish to be rejected.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Locally build with this changes.
 
 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
